### PR TITLE
fix(BDB-2678): dropdown options string[]

### DIFF
--- a/src/components/prime/index.tsx
+++ b/src/components/prime/index.tsx
@@ -44,8 +44,8 @@ export { Tree } from 'primereact/tree';
 export { TreeSelect } from 'primereact/treeselect';
 export { TreeTable } from 'primereact/treetable';
 
-const valueTemplate = (option, {optionLabel, name}) => {
-    const value = option?.[optionLabel || 'label'];
+const valueTemplate = (option, {optionLabel, name, value: selectedValue}) => {
+    const value = option?.[optionLabel || 'label'] || selectedValue;
     return value
         ? <span data-testid={name}>{value}</span>
         : 'empty';


### PR DESCRIPTION
Given that options of Dropdown are passed as array of strings, when an option is selected the Dropdown displays "empty" as selected.